### PR TITLE
chore: open `net/wifibox-core` 0.13.0

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -22,7 +22,6 @@ OPTIONS_SINGLE_RECOVERY=	RECOVER_RESTART_VMM \
 				RECOVER_NONE
 
 OPTIONS_DEFAULT=		RECOVER_RESTART_VMM
-OPTIONS_EXCLUDE_FreeBSD_12=	BHYVE_PLUS
 
 RECOVER_RESTART_VMM_DESC=	Restart the vmm(4) kernel module on resume
 RECOVER_SUSPEND_GUEST_DESC=	Stop the guest on suspend, start on resume
@@ -33,7 +32,7 @@ BHYVE_PLUS_DESC=		Use bhyve+ (experimental)
 
 .include <bsd.port.options.mk>
 
-.if ${PORT_OPTIONS:MBHYVE_PLUS} || (${OSVERSION} < 1300000)
+.if ${PORT_OPTIONS:MBHYVE_PLUS}
 RUN_DEPENDS+=	bhyve+>0:sysutils/bhyve+
 _BHYVE_PLUS=	yes
 .endif

--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox-core
-PORTVERSION=	0.12.0
+PORTVERSION=	0.13.0
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
@@ -12,8 +12,6 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 ONLY_FOR_ARCHS=	amd64
 
 RUN_DEPENDS=	grub2-bhyve>0:sysutils/grub2-bhyve
-
-OPTIONS_DEFINE=			BHYVE_PLUS
 
 OPTIONS_SINGLE=			RECOVERY
 OPTIONS_SINGLE_RECOVERY=	RECOVER_RESTART_VMM \
@@ -28,28 +26,17 @@ RECOVER_SUSPEND_GUEST_DESC=	Stop the guest on suspend, start on resume
 RECOVER_SUSPEND_VMM_DESC=	Unload vmm(4) on suspend, and reload on resume
 RECOVER_NONE_DESC=		No recovery for suspend/resume
 
-BHYVE_PLUS_DESC=		Use bhyve+ (experimental)
-
 .include <bsd.port.options.mk>
-
-.if ${PORT_OPTIONS:MBHYVE_PLUS}
-RUN_DEPENDS+=	bhyve+>0:sysutils/bhyve+
-_BHYVE_PLUS=	yes
-.endif
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
+GH_TAGNAME=	35ee9d2d77b672871de1fa813270a40c21f3d8a2
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \
 		GUEST_MAN=${LOCALBASE}/man/man5/wifibox-alpine.5.gz \
 		VERSION=${PORTVERSION} \
 		RECOVERY_METHOD=${PORT_OPTIONS:MRECOVER_*:S/RECOVER_//:tl}
-.if defined(_BHYVE_PLUS)
-MAKE_ARGS+=	BHYVE=${LOCALBASE}/sbin/bhyve \
-		BHYVECTL=${LOCALBASE}/sbin/bhyvectl \
-		VMM_KO=${KMODDIR}/vmm.ko
-.endif
 
 .include <bsd.port.mk>

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1695716184
-SHA256 (pgj-freebsd-wifibox-0.12.0_GH0.tar.gz) = 4f418c7b0f93f497677a2168ee34d719e7a175c63ee45dce7b3b5d8efdc4457e
-SIZE (pgj-freebsd-wifibox-0.12.0_GH0.tar.gz) = 16838
+TIMESTAMP = 1704379055
+SHA256 (pgj-freebsd-wifibox-0.13.0-35ee9d2d77b672871de1fa813270a40c21f3d8a2_GH0.tar.gz) = 5a645d9fef41f344785d2d734ae760d4d038bc051bdf4d57133b2b3d5a6ab3c6
+SIZE (pgj-freebsd-wifibox-0.13.0-35ee9d2d77b672871de1fa813270a40c21f3d8a2_GH0.tar.gz) = 16740


### PR DESCRIPTION
- Drop `bhyve+` and FreeBSD 12 support
- Add support for definition of multiple PCI pass-through devices