### PR TITLE
chore(`net/wifibox`): bump to 1.4.0

### DIFF
--- a/net/wifibox/Makefile
+++ b/net/wifibox/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox
-PORTVERSION=	1.3.0
+PORTVERSION=	1.4.0
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com


### PR DESCRIPTION
Start preparing for releasing the next minor version of Wifibox.