### PR TITLE
chore(`net/wifibox-core`): chase release of `0.13.0`

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,6 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	c59a3860817fdd504c7c4b1c47210969c3bfd4aa
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1711304634
-SHA256 (pgj-freebsd-wifibox-0.13.0-c59a3860817fdd504c7c4b1c47210969c3bfd4aa_GH0.tar.gz) = 5504faf648bb26cb35f3d04dee07322e4b5c6aa01954cfab78978cd26d02677d
-SIZE (pgj-freebsd-wifibox-0.13.0-c59a3860817fdd504c7c4b1c47210969c3bfd4aa_GH0.tar.gz) = 17902
+TIMESTAMP = 1711536358
+SHA256 (pgj-freebsd-wifibox-0.13.0_GH0.tar.gz) = 06714b82442a2abf2730c8148e2cf700335bd72e30f9769f7134ef728c4b67b7
+SIZE (pgj-freebsd-wifibox-0.13.0_GH0.tar.gz) = 17904


### PR DESCRIPTION
Update the `net/wifibox-core` to finalize the 0.13.0 release, see the [change log](https://github.com/pgj/freebsd-wifibox/releases/tag/0.13.0) for more information.