### PR TITLE
chore(`net/wifibox`): bump to 1.4.1

### DIFF
--- a/net/wifibox/Makefile
+++ b/net/wifibox/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox
-PORTVERSION=	1.4.0
+PORTVERSION=	1.4.1
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com


### PR DESCRIPTION
Prepare a new bug-fix release to address the background forking startup issue with `dhcpcd`.