### PR TITLE
chore(`net/wifibox-core`): sync with the FreeBSD ports tree

### DIFF
--- a/net/wifibox-core/pkg-plist
+++ b/net/wifibox-core/pkg-plist
@@ -2,8 +2,8 @@
 @sample etc/wifibox/core.conf.sample
 @sample etc/devd/wifibox.conf.sample
 etc/rc.d/wifibox
+sbin/wifibox
 share/man/man5/wifibox-guest.5.gz
 share/man/man8/wifibox.8.gz
-sbin/wifibox
 @preexec /usr/bin/touch /var/log/wifibox.log
 @preunexec /bin/rm -f /var/log/wifibox.log


### PR DESCRIPTION
There was a minor change recently to the version in the FreeBSD ports tree of the packaging list, which seems valid.  Import them to this tree to avoid reverting them later.