### PR TITLE
fix(`net/wifibox-alpine`): check path of the run-time environment that Linuxulator uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ either.
 # kldload linux64
 ```
 
+Sometimes the build may crash with an `Abort trap` message, which
+results in `Error 134` for `make`.  This happens when trying to run
+Linux binaries atop FreeBSD, such as the APK package manager for
+installing the components.  This usually happens on systems that have
+not had the Linuxulator used before and may not have the
+`/compat/linux` directory created, which is expected to be present.
+This issue can be fixed as follows, for example.
+
+```console
+# mkdir -p /compat/linux
+```
+
 For `net/wifibox-core`, the default dependencies are follows, which
 could be also installed via packages.  The `socat` package is only
 required if the Unix Domain Socket pass-through is going to be

--- a/net/wifibox-alpine/Makefile
+++ b/net/wifibox-alpine/Makefile
@@ -160,9 +160,19 @@ _IPW2200_FIRMWARE=	iwi/ipw2200-bss \
 _MT76_FIRMWARE=		2135e201e7a9339e018d4e2d4a33c73266e674d7
 
 _LINUX64_KMOD!=		(kldstat -qn linux64 && echo "found") || echo ""
+_LINUX_EMUL_PATH!=	(sysctl -qn compat.linux.emul_path) || echo ""
+_LINUX_EP_EXISTS!=	(test -d "${_LINUX_EMUL_PATH}" && echo "found") || echo ""
 
-.if empty(_LINUX64_KMOD)
+.if empty(IGNORE) && empty(_LINUX64_KMOD)
 IGNORE=	needs the linux64 kernel module to build
+.endif
+
+.if empty(IGNORE) && empty(_LINUX_EMUL_PATH)
+IGNORE=	needs compat.linux.emul_path to be set
+.endif
+
+.if empty(IGNORE) && empty(_LINUX_EP_EXISTS)
+IGNORE= needs compat.linux.emul_path to point to an existing directory
 .endif
 
 pre-everything::


### PR DESCRIPTION
It can cause problems if the path does not exist for `compat.linux.emul_path`.  Mention the possibility of this for the users, and implement checks around that to prevent this from happening.