### PR TITLE
chore(`net/wifibox-alpine`): Update to `20240420`

### DIFF
--- a/net/wifibox-alpine/Makefile
+++ b/net/wifibox-alpine/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox-alpine
-PORTVERSION=	20240328
+PORTVERSION=	20240420
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
@@ -43,11 +43,14 @@ COMP_ZSTD_DESC=		zstd
 
 UDS_PASSTHRU_DESC=		Control socket pass-through (wpa_supplicant/hostapd)
 IPV6_DESC=			IPv6 support
+
 APP_HOSTAPD_DESC=		Access Point (hostapd)
 APP_WPA_SUPPLICANT_DESC=	WPA Supplicant (wpa_supplicant)
+
 XX_MDNS_DESC=			mDNS Responder Daemon
 XX_FORWARDING_DESC=		User-space forwarding
 XX_TCPDUMP_DESC=		Packet analysis with tcpdump
+XX_DRIVER_WL_DESC=		Broadcom 802.11 STA driver (+ firmware, exclusive)
 
 KERN_LTS_DESC=			Linux LTS (6.6.x)
 KERN_EDGE_DESC=			Linux edge (6.8.x)
@@ -59,7 +62,7 @@ OPTIONS_GROUP+=		FIRMWARE
 OPTIONS_GROUP_FIRMWARE=	FW_ATH10K FW_ATH11K FW_ATH12K FW_ATMEL FW_B43 FW_B43LEGACY\
 			FW_BRCM FW_IPW2100 FW_IPW2200 FW_IWL3945 FW_IWL4965 FW_IWLWIFI\
 			FW_MEDIATEK FW_MARVELL FW_RT61 FW_RTLWIFI FW_RTW88 FW_RTW89\
-			FW_TI
+			FW_RTW89_FIX FW_TI
 OPTIONS_GROUP_EXTRAS+=	XX_DRIVER_WL
 
 OPTIONS_DEFAULT+=	FW_ATH10K FW_ATH11K FW_ATH12K FW_BRCM FW_IWLWIFI FW_MEDIATEK\
@@ -84,16 +87,20 @@ FW_RTLWIFI_DESC=	Realtek 802.11n
 FW_RTW88_DESC=		Realtek 802.11ac
 FW_RTW89_DESC=		Realtek 802.11ax
 FW_TI_DESC=		Texas Instruments WL1xxx 802.11b/g/n
-
-XX_DRIVER_WL_DESC=	Broadcom 802.11 STA driver (+ firmware, exclusive)
+.elif ${FLAVOR:U} == rtw89
+OPTIONS_GROUP+=		FIRMWARE
+OPTIONS_GROUP_FIRMWARE=	FW_RTW89_FIX
 .endif
+
+FW_RTW89_FIX_IMPLIES=	FW_RTW89
+FW_RTW89_FIX_DESC=	Realtek 802.11ax: apply fix for HP/Lenovo
 
 _GITHUB_SITE=	https://github.com/pgj/freebsd-wifibox-alpine/releases/download
 
 USE_GITHUB=	nodefault
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox-alpine:scripts
-GH_TAGNAME=	fe9b384e45c57b0cfafe5e5b3931ba163f4230fd:scripts
+GH_TAGNAME=	e4aebbaa9919c4493485f20f9de4b582cd17a4ec:scripts
 
 ALPINE_VERSION=	3.19.1
 ALPINE_DATE=	2024.03.23
@@ -392,6 +399,7 @@ _APK_FILES+=	${_DISTDIR}/${package:C@^([^:]*):.*$@\1@}.apk
 _GUESTDIR=	${WRKSRC}/guest
 _ETCDIR=	${_GUESTDIR}/etc
 _FIRMWAREDIR=	${_GUESTDIR}/lib/firmware
+_MODPROBEDDIR=	${_ETCDIR}/modprobe.d
 
 .if ${PORT_OPTIONS:MFW_ATMEL} || make(makesum)
 DISTFILES+=	${_ATMEL_FIRMWARE}.tar.gz:atmel
@@ -467,6 +475,11 @@ pre-build:
 	${TAR} -xf ${_DISTDIR}/${_MT76_FIRMWARE}.zip \
 		-C ${_FIRMWAREDIR} --strip-components 2 \
 		*/firmware/mt76??_e?.bin
+.endif
+.if ${PORT_OPTIONS:MFW_RTW89} && ${PORT_OPTIONS:MFW_RTW89_FIX}
+	${MKDIR} ${_MODPROBEDDIR}
+	${ECHO} "options rtw89pci disable_aspm_l1=y disable_aspm_l1ss=y" \
+		> ${_MODPROBEDDIR}/rtw89.conf
 .endif
 
 post-install:

--- a/net/wifibox-alpine/distinfo
+++ b/net/wifibox-alpine/distinfo
@@ -1,4 +1,4 @@
-TIMESTAMP = 1711611047
+TIMESTAMP = 1713128742
 SHA256 (wifibox-alpine/alpine-minirootfs-3.19.1-x86_64.tar.gz) = 185123ceb6e7d08f2449fff5543db206ffb79decd814608d399ad447e08fa29e
 SIZE (wifibox-alpine/alpine-minirootfs-3.19.1-x86_64.tar.gz) = 3285677
 SHA256 (wifibox-alpine/linux-firmware-20240312.tar.gz) = 89cbac35d1bd21ebf64936d764ccd01d4e0b6cde973e3b940f8ad2bac9086ec8
@@ -89,5 +89,5 @@ SHA256 (wifibox-alpine/broadcom-wl-6.30.163.46.tar.bz2) = a07c3b6b277833c7dbe61d
 SIZE (wifibox-alpine/broadcom-wl-6.30.163.46.tar.bz2) = 7684610
 SHA256 (wifibox-alpine/2135e201e7a9339e018d4e2d4a33c73266e674d7.zip) = 7c9c69184bea159c6a6a885ffbafe878d9bb0e5d6d0fc2aeba010ee42c8fdd33
 SIZE (wifibox-alpine/2135e201e7a9339e018d4e2d4a33c73266e674d7.zip) = 12509641
-SHA256 (wifibox-alpine/pgj-freebsd-wifibox-alpine-fe9b384e45c57b0cfafe5e5b3931ba163f4230fd_GH0.tar.gz) = ca977198e9ce1e0fa4e95cda5c2f435ad6d829f2edd597ea697e0a58dfdb6475
-SIZE (wifibox-alpine/pgj-freebsd-wifibox-alpine-fe9b384e45c57b0cfafe5e5b3931ba163f4230fd_GH0.tar.gz) = 208406
+SHA256 (wifibox-alpine/pgj-freebsd-wifibox-alpine-e4aebbaa9919c4493485f20f9de4b582cd17a4ec_GH0.tar.gz) = 814da8e5d573dce7413dcd1e28410da5b1f1b79c15915654a206b98786a5dc5f
+SIZE (wifibox-alpine/pgj-freebsd-wifibox-alpine-e4aebbaa9919c4493485f20f9de4b582cd17a4ec_GH0.tar.gz) = 208432


### PR DESCRIPTION
- New port option for adding the rtw89 HP/Lenovo fix
- Remove APK metadata from the root file system