### PR TITLE
chore(`net/wifibox-core`): Remove `nmdm(4)` device management

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox-core
-PORTVERSION=	0.13.0
+PORTVERSION=	0.14.0
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
@@ -31,6 +31,7 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
+GH_TAGNAME=	08f4764465dacd010fb1cb497b3f01fc80cb41b2
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1711536358
-SHA256 (pgj-freebsd-wifibox-0.13.0_GH0.tar.gz) = 06714b82442a2abf2730c8148e2cf700335bd72e30f9769f7134ef728c4b67b7
-SIZE (pgj-freebsd-wifibox-0.13.0_GH0.tar.gz) = 17904
+TIMESTAMP = 1724995153
+SHA256 (pgj-freebsd-wifibox-0.14.0-08f4764465dacd010fb1cb497b3f01fc80cb41b2_GH0.tar.gz) = 12e727712d795ddb78489d7e60d10f49ded37a774a67b7ce201d93af0b7c6e74
+SIZE (pgj-freebsd-wifibox-0.14.0-08f4764465dacd010fb1cb497b3f01fc80cb41b2_GH0.tar.gz) = 17679


### PR DESCRIPTION
Relates to https://github.com/pgj/freebsd-wifibox/issues/104