### PR TITLE
chore(`net/wifibox-core`): chase recent updates

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,7 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	08f4764465dacd010fb1cb497b3f01fc80cb41b2
+GH_TAGNAME=	4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1724995153
-SHA256 (pgj-freebsd-wifibox-0.14.0-08f4764465dacd010fb1cb497b3f01fc80cb41b2_GH0.tar.gz) = 12e727712d795ddb78489d7e60d10f49ded37a774a67b7ce201d93af0b7c6e74
-SIZE (pgj-freebsd-wifibox-0.14.0-08f4764465dacd010fb1cb497b3f01fc80cb41b2_GH0.tar.gz) = 17679
+TIMESTAMP = 1726384954
+SHA256 (pgj-freebsd-wifibox-0.14.0-4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9_GH0.tar.gz) = 150ccb4018824e125621d3273893e5f23a831297a07d50597bea9f2ff232b6b8
+SIZE (pgj-freebsd-wifibox-0.14.0-4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9_GH0.tar.gz) = 18042


### PR DESCRIPTION
This PR is to bring the following changes:

- https://github.com/pgj/freebsd-wifibox/pull/107
- https://github.com/pgj/freebsd-wifibox/pull/110
- https://github.com/pgj/freebsd-wifibox/pull/114
- https://github.com/pgj/freebsd-wifibox/pull/115
- https://github.com/pgj/freebsd-wifibox/pull/117