### PR TITLE
chore(`net/wifibox-core`): chase recent updates

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,12 +31,19 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9
+GH_TAGNAME=	448716069ff1bef68a4645efde2fbccdfe25c07f
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \
 		GUEST_MAN=${LOCALBASE}/share/man/man5/wifibox-alpine.5.gz \
 		VERSION=${PORTVERSION} \
 		RECOVERY_METHOD=${PORT_OPTIONS:MRECOVER_*:S/RECOVER_//:tl}
+
+.if ${OSVERSION} > 1400089
+MAKE_ARGS+=	DEVD_FIX=
+PLIST_SUB+=	DEVD_FIX="@comment "
+.else
+PLIST_SUB+=	DEVD_FIX=""
+.endif
 
 .include <bsd.port.mk>

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1726384954
-SHA256 (pgj-freebsd-wifibox-0.14.0-4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9_GH0.tar.gz) = 150ccb4018824e125621d3273893e5f23a831297a07d50597bea9f2ff232b6b8
-SIZE (pgj-freebsd-wifibox-0.14.0-4abcf0936fdd5a04fcd7fd53811ebb5aab7b70a9_GH0.tar.gz) = 18042
+TIMESTAMP = 1727335479
+SHA256 (pgj-freebsd-wifibox-0.14.0-448716069ff1bef68a4645efde2fbccdfe25c07f_GH0.tar.gz) = 101ad1e9656157da3bc1b871ecc499d796b38f9e8955d8ecb0214d7a7d0209d3
+SIZE (pgj-freebsd-wifibox-0.14.0-448716069ff1bef68a4645efde2fbccdfe25c07f_GH0.tar.gz) = 18364

--- a/net/wifibox-core/pkg-plist
+++ b/net/wifibox-core/pkg-plist
@@ -1,6 +1,6 @@
 @sample etc/wifibox/bhyve.conf.sample
 @sample etc/wifibox/core.conf.sample
-@sample etc/devd/wifibox.conf.sample
+%%DEVD_FIX%%@sample etc/devd/wifibox.conf.sample
 etc/rc.d/wifibox
 sbin/wifibox
 share/man/man5/wifibox-guest.5.gz


### PR DESCRIPTION
Accommodate the following change in the port:

- https://github.com/pgj/freebsd-wifibox/pull/121 (which fixes https://github.com/pgj/freebsd-wifibox/issues/120)