### PR TITLE
chore(`net/wifibox-core`): Chase changes

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,7 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	575f789c328a3b823e8deacf79dd520983a17cb2
+GH_TAGNAME=	a499a87ccc425842f8bc96211c46641e854d83e8
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1727416690
-SHA256 (pgj-freebsd-wifibox-0.14.0-575f789c328a3b823e8deacf79dd520983a17cb2_GH0.tar.gz) = 878c7aa8c3ab01fe56d9b5def7fd2a3d4265d1d957311a5db0c26acd076b17b5
-SIZE (pgj-freebsd-wifibox-0.14.0-575f789c328a3b823e8deacf79dd520983a17cb2_GH0.tar.gz) = 18331
+TIMESTAMP = 1727468210
+SHA256 (pgj-freebsd-wifibox-0.14.0-a499a87ccc425842f8bc96211c46641e854d83e8_GH0.tar.gz) = 2e47cbc22ef4c67f9bd59d9d79510b9e6dc529b7215e3fab3079560915cb3e3e
+SIZE (pgj-freebsd-wifibox-0.14.0-a499a87ccc425842f8bc96211c46641e854d83e8_GH0.tar.gz) = 18410


### PR DESCRIPTION
This PR updates the port to hold the following changes:

- https://github.com/pgj/freebsd-wifibox/pull/124
- https://github.com/pgj/freebsd-wifibox/pull/125