### PR TITLE
chore(`net/wifibox-core`): chase release of `0.14.0`

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,6 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	df4921e18117da53fb4155de0581f12b875d08da
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1727474338
-SHA256 (pgj-freebsd-wifibox-0.14.0-df4921e18117da53fb4155de0581f12b875d08da_GH0.tar.gz) = 22671c75099171c151876144f4b7102d1ccb00b204d5e0fa352894322acab24e
-SIZE (pgj-freebsd-wifibox-0.14.0-df4921e18117da53fb4155de0581f12b875d08da_GH0.tar.gz) = 18425
+TIMESTAMP = 1727478244
+SHA256 (pgj-freebsd-wifibox-0.14.0_GH0.tar.gz) = 7cba1145fe2ae366d3677cb54a05f58524d78295e5edf451f9f4e7daff515fc1
+SIZE (pgj-freebsd-wifibox-0.14.0_GH0.tar.gz) = 18428


### PR DESCRIPTION
Update `net/wifibox-core` to finalize the 0.14.0 release, see the [change log](https://github.com/pgj/freebsd-wifibox/releases/tag/0.14.0) for more information.