### PR TITLE
chore(`ci`): bump FreeBSD versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ jobs:
   checks:
     strategy:
       matrix:
-        version: ["13.4", "14.1"]
+        version: ["13.5", "14.2"]
     runs-on: ubuntu-latest
     name: Continuous Integration
     steps:


### PR DESCRIPTION
- FreeBSD 13.4 → [13.5](https://www.freebsd.org/releases/13.5R/) (released on March 11, 2025)
- FreeBSD 14.1 → [14.2](https://www.freebsd.org/releases/14.2R/) (released on December 3, 2024)
