### PR TITLE
chore(`net/wifibox-core`): open 0.15.0

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox-core
-PORTVERSION=	0.14.0
+PORTVERSION=	0.15.0
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
@@ -31,6 +31,7 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
+GH_TAGNAME=	d160edc208a4ee2811e5a0465ea5ebc518f9aa9a
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1727478244
-SHA256 (pgj-freebsd-wifibox-0.14.0_GH0.tar.gz) = 7cba1145fe2ae366d3677cb54a05f58524d78295e5edf451f9f4e7daff515fc1
-SIZE (pgj-freebsd-wifibox-0.14.0_GH0.tar.gz) = 18428
+TIMESTAMP = 1742766104
+SHA256 (pgj-freebsd-wifibox-0.15.0-d160edc208a4ee2811e5a0465ea5ebc518f9aa9a_GH0.tar.gz) = 142ecb916edca1a2c8ef61cfc71409f55b0b1fa1d7331519b9da8dbba9cab2ce
+SIZE (pgj-freebsd-wifibox-0.15.0-d160edc208a4ee2811e5a0465ea5ebc518f9aa9a_GH0.tar.gz) = 19194


### PR DESCRIPTION
- Consider built-in kernel modules on checking their presence ([freebsd-wifibox#136](https://github.com/pgj/freebsd-wifibox/issues/136))