### PR TITLE
fix(`net/wifibox`): package comment line

### DIFF
--- a/net/wifibox/Makefile
+++ b/net/wifibox/Makefile
@@ -3,7 +3,7 @@ PORTVERSION=	1.5.0
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
-COMMENT=	Wireless card driver via virtualized Linux
+COMMENT=	Embedded (virtualized) wireless router
 WWW=		https://github.com/pgj/freebsd-wifibox
 
 ONLY_FOR_ARCHS=	amd64


### PR DESCRIPTION
Tweak the package comment to make it say less ambitious.  Wifibox is not a device driver but an embedded router.  This way users may get less confused about what it could effectively deliver.