### PR TITLE
chore(`net/wifibox-core`): chase the release of `0.15.0`

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,6 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	d160edc208a4ee2811e5a0465ea5ebc518f9aa9a
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1742766104
-SHA256 (pgj-freebsd-wifibox-0.15.0-d160edc208a4ee2811e5a0465ea5ebc518f9aa9a_GH0.tar.gz) = 142ecb916edca1a2c8ef61cfc71409f55b0b1fa1d7331519b9da8dbba9cab2ce
-SIZE (pgj-freebsd-wifibox-0.15.0-d160edc208a4ee2811e5a0465ea5ebc518f9aa9a_GH0.tar.gz) = 19194
+TIMESTAMP = 1743204322
+SHA256 (pgj-freebsd-wifibox-0.15.0_GH0.tar.gz) = c9a63a04cc0989a2fc0e0c21ff253411f03aa1b53a871ccac32f3d5b7f0b5c91
+SIZE (pgj-freebsd-wifibox-0.15.0_GH0.tar.gz) = 19204


### PR DESCRIPTION
Update `net/wifibox-core` to finalize the `0.15.0` release, see the [change log](https://github.com/pgj/freebsd-wifibox/releases/tag/0.15.0) for more information.
