### PR TITLE
chore(`net/wifibox-alpine`): sync with the FreeBSD ports tree

### DIFF
--- a/net/wifibox-alpine/Makefile
+++ b/net/wifibox-alpine/Makefile
@@ -14,7 +14,7 @@ EXTRACT_ONLY=	${_DISTFILES:M*_GH0.tar.gz}
 
 BUILD_DEPENDS=	gtar>0:archivers/gtar \
 		patchelf>0:sysutils/patchelf \
-		squashfs-tools-ng>0:sysutils/squashfs-tools-ng
+		squashfs-tools-ng>0:filesystems/squashfs-tools-ng
 
 .include "${.CURDIR}/flavors.mk"
 


### PR DESCRIPTION
Import the respective portion of the following sweeping change:

https://cgit.freebsd.org/ports/commit/?id=6e2da9672f79f44048d597f0f61e4646cdeade9d