### PR TITLE
chore(`ci`): upgrade to FreeBSD 14.3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ jobs:
   checks:
     strategy:
       matrix:
-        version: ["13.5", "14.2"]
+        version: ["13.5", "14.3"]
     runs-on: ubuntu-latest
     name: Continuous Integration
     env:


### PR DESCRIPTION
Upgrade the FreeBSD 14 build environment to [14.3](https://www.freebsd.org/releases/14.3R/) (released on June 10, 2025).