### PR TITLE
chore(`ci`): unstuck jobs & reduce resource consumption

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,8 @@ jobs:
         version: ["13.5", "14.2"]
     runs-on: ubuntu-latest
     name: Continuous Integration
+    env:
+      BATCH: true
     steps:
     - uses: actions/checkout@v4
     - name: "FreeBSD ${{ matrix.version }}"
@@ -16,6 +18,7 @@ jobs:
       with:
         release: "${{ matrix.version }}"
         usesh: true
+        envs: BATCH
         cpu: 1
         arch: x86_64
         mem: 1024


### PR DESCRIPTION
Recent versions of the GitHub Actions runner caused the jobs hang indefinitely, possibly due to changes to the ways how terminals are emulated.  Switch ports to non-interactive mode to avoid the related issues.  While there, reduce the amount of CPUs and memory needed to complete the builds for the greater good.
