### PR TITLE
chore(`net/wifibox-alpine`): use a package site backed by GitHub Pages

### DIFF
--- a/net/wifibox-alpine/Makefile
+++ b/net/wifibox-alpine/Makefile
@@ -88,7 +88,7 @@ FW_TI_DESC=		Texas Instruments WL1xxx 802.11b/g/n
 XX_DRIVER_WL_DESC=	Broadcom 802.11 STA driver (+ firmware, exclusive)
 .endif
 
-_GITHUB_SITE=	https://github.com/pgj/freebsd-wifibox-alpine/releases/download
+_GITHUB_SITE=	https://pgj.github.io/freebsd-wifibox/alpine/main
 
 USE_GITHUB=	nodefault
 GH_ACCOUNT=	pgj


### PR DESCRIPTION
This will make it possible for publishing packages that were built via GitHub Actions and then added to the `git` repository in the background.