### PR TITLE
chore(`net/wifibox-core`): open 0.15.1

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	wifibox-core
-PORTVERSION=	0.15.0
+PORTVERSION=	0.15.1
 CATEGORIES=	net
 
 MAINTAINER=	pali.gabor@gmail.com
@@ -31,6 +31,7 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
+GH_TAGNAME=	24c44b26e485d718584160577c06e663f95f2d2b
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1743204322
-SHA256 (pgj-freebsd-wifibox-0.15.0_GH0.tar.gz) = c9a63a04cc0989a2fc0e0c21ff253411f03aa1b53a871ccac32f3d5b7f0b5c91
-SIZE (pgj-freebsd-wifibox-0.15.0_GH0.tar.gz) = 19204
+TIMESTAMP = 1758685319
+SHA256 (pgj-freebsd-wifibox-0.15.1-24c44b26e485d718584160577c06e663f95f2d2b_GH0.tar.gz) = 15f0ea524c1d71fd6f502c7460656ea52022337b3ae6a12a9331434ec17e6517
+SIZE (pgj-freebsd-wifibox-0.15.1-24c44b26e485d718584160577c06e663f95f2d2b_GH0.tar.gz) = 19210


### PR DESCRIPTION
- Improve wording about the mention of AMD-Vi on the manual page ([freebsd-wifibox#157](https://github.com/pgj/freebsd-wifibox/pull/157))
