### PR TITLE
chore(`net/wifibox-core`): chase the release of `0.15.1`

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -31,7 +31,6 @@ RECOVER_NONE_DESC=		No recovery for suspend/resume
 USE_GITHUB=	yes
 GH_ACCOUNT=	pgj
 GH_PROJECT=	freebsd-wifibox
-GH_TAGNAME=	24c44b26e485d718584160577c06e663f95f2d2b
 
 NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \

--- a/net/wifibox-core/distinfo
+++ b/net/wifibox-core/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1758685319
-SHA256 (pgj-freebsd-wifibox-0.15.1-24c44b26e485d718584160577c06e663f95f2d2b_GH0.tar.gz) = 15f0ea524c1d71fd6f502c7460656ea52022337b3ae6a12a9331434ec17e6517
-SIZE (pgj-freebsd-wifibox-0.15.1-24c44b26e485d718584160577c06e663f95f2d2b_GH0.tar.gz) = 19210
+TIMESTAMP = 1758842421
+SHA256 (pgj-freebsd-wifibox-0.15.1_GH0.tar.gz) = c581c4e7e9dacc7edebd153818cd252eaa2a0c431fd1506f4f778dfa165d9b9a
+SIZE (pgj-freebsd-wifibox-0.15.1_GH0.tar.gz) = 19228


### PR DESCRIPTION
Update `net/wifibox-core` to finalize the `0.15.1` release, see the [change log](https://github.com/pgj/freebsd-wifibox/releases/tag/0.15.1) for more information.