### PR TITLE
chore: sync with the Ports Collection for dropping support for FreeBSD 13

### DIFF
--- a/net/wifibox-core/Makefile
+++ b/net/wifibox-core/Makefile
@@ -37,13 +37,7 @@ NO_BUILD=	yes
 MAKE_ARGS+=	GUEST_ROOT=${LOCALBASE}/share/wifibox \
 		GUEST_MAN=${LOCALBASE}/share/man/man5/wifibox-alpine.5.gz \
 		VERSION=${PORTVERSION} \
-		RECOVERY_METHOD=${PORT_OPTIONS:MRECOVER_*:S/RECOVER_//:tl}
-
-.if ${OSVERSION} > 1400089
-MAKE_ARGS+=	DEVD_FIX=
-PLIST_SUB+=	DEVD_FIX="@comment "
-.else
-PLIST_SUB+=	DEVD_FIX=""
-.endif
+		RECOVERY_METHOD=${PORT_OPTIONS:MRECOVER_*:S/RECOVER_//:tl} \
+		DEVD_FIX=
 
 .include <bsd.port.mk>

--- a/net/wifibox-core/pkg-plist
+++ b/net/wifibox-core/pkg-plist
@@ -1,5 +1,6 @@
 @sample etc/wifibox/bhyve.conf.sample
 @sample etc/wifibox/core.conf.sample
+@comment @sample etc/devd/wifibox.conf.sample
 etc/rc.d/wifibox
 sbin/wifibox
 share/man/man5/wifibox-guest.5.gz

--- a/net/wifibox-core/pkg-plist
+++ b/net/wifibox-core/pkg-plist
@@ -1,6 +1,5 @@
 @sample etc/wifibox/bhyve.conf.sample
 @sample etc/wifibox/core.conf.sample
-%%DEVD_FIX%%@sample etc/devd/wifibox.conf.sample
 etc/rc.d/wifibox
 sbin/wifibox
 share/man/man5/wifibox-guest.5.gz


### PR DESCRIPTION
Import the patch from the FreeBSD Ports Collection that drops support for FreeBSD 13.  This is the filtered version that includes changes only to the `net/wifibox-core` port.