### PR TITLE
chore(`ci`): replace `gitup` for vanilla `git`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,9 +23,10 @@ jobs:
         arch: x86_64
         mem: 1024
         prepare: |
-          pkg install -q -y gitup portconfig
+          pkg install -q -y git-lite portconfig
           pkg install -q -y gtar patchelf squashfs-tools-ng mtools bhyve-firmware socat
-          gitup ports -v0
+          git clone --depth=1 --filter=blob:none --sparse https://git.freebsd.org/ports.git /usr/ports
+          cd /usr/ports && git sparse-checkout set Mk Templates Keywords
 
           kldload linux64
           mkdir -p /compat/linux


### PR DESCRIPTION
Recently [an issue with `gitup`](https://github.com/johnmehr/gitup/issues/108) broke the CI and some people noted that almost the same level of efficiency can be reached by the standard `git` client &mdash; this is just a matter of flags. While implementing this change, leverage the sparse checkout feature and get the files for framework subdirectories of the Ports Collection only, since those are the ones that are actually needed for the builds to succeed.
